### PR TITLE
fix(setup): specify minimum dependencies to run script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,11 @@ setup(
     version="0.1",
     packages=find_packages(),
     install_requires=[
-        "google-cloud-aiplatform",
-        "google-cloud-storage",
         "keras==2.14.0",
         "Keras-Preprocessing",
-        "viam-sdk==0.25.2",
-        "protobuf==4.25.3",
+        "numpy<2",
+        "tensorflow==2.14.0",
+        "viam-sdk",
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
When attempting to run this training script locally, there was an error due to Tensorflow not being installed. After referring to the [Keras docs](https://keras.io/getting_started/#tensorflow--keras-2-backwards-compatibility), I noticed the requirement for version matching the Tensorflow version with Keras 2. Then, after adding tensorflow, I ran into a conflict with numpy v2, which was pulled in by `Keras-Preprocessing`, so I pinned it to `<2`. 

A few questions about the dependencies for this script (and other custom training scripts):

1. Do we need the `google-cloud-*` dependencies if the script isn't interacting with GCP directly?
2. Why are we pinned to Keras 2 instead of using the latest version?
3. Why are we pinning `viam-sdk`?
4. Should we also be defining supported Python versions to the setup.py as well? The documentation doesn't specify what version is used by Vertex when running the script, which could lead to annoying errors if developers don't know what to test against. 